### PR TITLE
Move locations support into separate package

### DIFF
--- a/HUnit.cabal
+++ b/HUnit.cabal
@@ -25,6 +25,7 @@ source-repository head
 Library
     Build-Depends:
         base == 4.*,
+        with-location >= 0.1.0,
         deepseq
     Exposed-Modules:
         Test.HUnit.Base,

--- a/Test/HUnit/Base.hs
+++ b/Test/HUnit/Base.hs
@@ -1,10 +1,4 @@
-{-# LANGUAGE CPP #-}
-#if MIN_VERSION_base(4,8,1)
-#define HAS_SOURCE_LOCATIONS
-{-# LANGUAGE ImplicitParams #-}
-{-# LANGUAGE ConstrainedClassMethods #-}
-#endif
-
+{-# LANGUAGE FlexibleContexts #-}
 -- | Basic definitions for the HUnit library.
 --
 --   This module contains what you need to create assertions and test cases and
@@ -44,15 +38,8 @@ module Test.HUnit.Base
 )
 where
 
-#ifdef HAS_SOURCE_LOCATIONS
-import           GHC.Stack
-#define with_loc (?loc :: CallStack) =>
-#else
-#define with_loc
-#endif
-
 import Control.Monad (unless, foldM)
-
+import Data.WithLocation
 
 -- Assertion Definition
 -- ====================
@@ -64,17 +51,19 @@ import Test.HUnit.Lang
 -- -------------------------------
 
 -- | Asserts that the specified condition holds.
-assertBool :: with_loc
+assertBool :: WithLocation (
               String    -- ^ The message that is displayed if the assertion fails
            -> Bool      -- ^ The condition
            -> Assertion
+           )
 assertBool msg b = unless b (assertFailure msg)
 
 -- | Signals an assertion failure if a non-empty message (i.e., a message
 -- other than @\"\"@) is passed.
-assertString :: with_loc
+assertString :: WithLocation (
                 String    -- ^ The message that is displayed with the assertion failure
              -> Assertion
+             )
 assertString s = unless (null s) (assertFailure s)
 
 -- | Asserts that the specified actual value is equal to the expected value.
@@ -83,11 +72,12 @@ assertString s = unless (null s) (assertFailure s)
 --
 -- If the prefix is the empty string (i.e., @\"\"@), then the prefix is omitted
 -- and only the expected and actual values are output.
-assertEqual :: with_loc (Eq a, Show a)
+assertEqual :: WithLocation ((Eq a, Show a)
                               => String -- ^ The message prefix
                               -> a      -- ^ The expected value
                               -> a      -- ^ The actual value
                               -> Assertion
+                              )
 assertEqual preface expected actual =
   unless (actual == expected) (assertFailure msg)
  where msg = (if null preface then "" else preface ++ "\n") ++
@@ -108,7 +98,7 @@ assertEqual preface expected actual =
 -- If more complex arrangements of assertions are needed, 'Test's and
 -- 'Testable' should be used.
 class Assertable t
- where assert :: with_loc t -> Assertion
+ where assert :: WithLocation (t -> Assertion)
 
 instance Assertable ()
  where assert = return
@@ -124,7 +114,7 @@ instance (Assertable t) => Assertable (IO t)
 
 -- | A specialized form of 'Assertable' to handle lists.
 class ListAssertable t
- where listAssert :: with_loc [t] -> Assertion
+ where listAssert :: WithLocation ([t] -> Assertion)
 
 instance ListAssertable Char
  where listAssert = assertString
@@ -176,26 +166,29 @@ infix  1 @?, @=?, @?=
 
 -- | Asserts that the condition obtained from the specified
 --   'AssertionPredicable' holds.
-(@?) :: with_loc (AssertionPredicable t)
+(@?) :: WithLocation ((AssertionPredicable t)
                                 => t          -- ^ A value of which the asserted condition is predicated
                                 -> String     -- ^ A message that is displayed if the assertion fails
                                 -> Assertion
+                                )
 predi @? msg = assertionPredicate predi >>= assertBool msg
 
 -- | Asserts that the specified actual value is equal to the expected value
 --   (with the expected value on the left-hand side).
-(@=?) :: with_loc (Eq a, Show a)
+(@=?) :: WithLocation ((Eq a, Show a)
                         => a -- ^ The expected value
                         -> a -- ^ The actual value
                         -> Assertion
+                        )
 expected @=? actual = assertEqual "" expected actual
 
 -- | Asserts that the specified actual value is equal to the expected value
 --   (with the actual value on the left-hand side).
-(@?=) :: with_loc (Eq a, Show a)
+(@?=) :: WithLocation ((Eq a, Show a)
                         => a -- ^ The actual value
                         -> a -- ^ The expected value
                         -> Assertion
+                        )
 actual @?= expected = assertEqual "" expected actual
 
 
@@ -223,7 +216,7 @@ instance Show Test where
 
 -- | Provides a way to convert data into a @Test@ or set of @Test@.
 class Testable t
- where test :: with_loc t -> Test
+ where test :: WithLocation (t -> Test)
 
 instance Testable Test
  where test = id
@@ -243,28 +236,31 @@ infixr 0 ~:
 
 -- | Creates a test case resulting from asserting the condition obtained
 --   from the specified 'AssertionPredicable'.
-(~?) :: with_loc (AssertionPredicable t)
+(~?) :: WithLocation ((AssertionPredicable t)
                                 => t       -- ^ A value of which the asserted condition is predicated
                                 -> String  -- ^ A message that is displayed on test failure
                                 -> Test
+                                )
 predi ~? msg = TestCase (predi @? msg)
 
 -- | Shorthand for a test case that asserts equality (with the expected
 --   value on the left-hand side, and the actual value on the right-hand
 --   side).
-(~=?) :: with_loc (Eq a, Show a)
+(~=?) :: WithLocation ((Eq a, Show a)
                         => a     -- ^ The expected value
                         -> a     -- ^ The actual value
                         -> Test
+                        )
 expected ~=? actual = TestCase (expected @=? actual)
 
 -- | Shorthand for a test case that asserts equality (with the actual
 --   value on the left-hand side, and the expected value on the right-hand
 --   side).
-(~?=) :: with_loc (Eq a, Show a)
+(~?=) :: WithLocation ((Eq a, Show a)
                         => a     -- ^ The actual value
                         -> a     -- ^ The expected value
                         -> Test
+                        )
 actual ~?= expected = TestCase (actual @?= expected)
 
 -- | Creates a test from the specified 'Testable', with the specified
@@ -272,7 +268,7 @@ actual ~?= expected = TestCase (actual @?= expected)
 --
 -- Since 'Test' is @Testable@, this can be used as a shorthand way of attaching
 -- a 'TestLabel' to one or more tests.
-(~:) :: with_loc (Testable t) => String -> t -> Test
+(~:) :: WithLocation ((Testable t) => String -> t -> Test)
 label ~: t = TestLabel label (test t)
 
 

--- a/Test/HUnit/Lang.hs
+++ b/Test/HUnit/Lang.hs
@@ -1,11 +1,5 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-
-{-# LANGUAGE CPP #-}
-#if MIN_VERSION_base(4,8,1)
-#define HAS_SOURCE_LOCATIONS
-{-# LANGUAGE ImplicitParams #-}
-#endif
-
 module Test.HUnit.Lang (
   Assertion,
   assertFailure,
@@ -23,25 +17,13 @@ module Test.HUnit.Lang (
 import           Control.DeepSeq
 import           Control.Exception as E
 import           Data.Typeable
-
-#ifdef HAS_SOURCE_LOCATIONS
-#if !(MIN_VERSION_base(4,9,0))
-import           GHC.SrcLoc
-#endif
-import           GHC.Stack
-#endif
+import           Data.WithLocation
 
 -- | When an assertion is evaluated, it will output a message if and only if the
 -- assertion fails.
 --
 -- Test cases are composed of a sequence of one or more assertions.
 type Assertion = IO ()
-
-data Location = Location {
-  locationFile :: FilePath
-, locationLine :: Int
-, locationColumn :: Int
-} deriving (Eq, Ord, Show)
 
 data HUnitFailure = HUnitFailure (Maybe Location) String
     deriving (Eq, Ord, Show, Typeable)
@@ -57,21 +39,11 @@ instance Exception HUnitFailure
 --        else assertFailure msg
 -- @
 assertFailure ::
-#ifdef HAS_SOURCE_LOCATIONS
-     (?loc :: CallStack) =>
-#endif
+     WithLocation (
      String -- ^ A message that is displayed with the assertion failure
   -> Assertion
+     )
 assertFailure msg = msg `deepseq` E.throwIO (HUnitFailure location msg)
-  where
-    location :: Maybe Location
-#ifdef HAS_SOURCE_LOCATIONS
-    location = case reverse (getCallStack ?loc) of
-      (_, loc) : _ -> Just $ Location (srcLocFile loc) (srcLocStartLine loc) (srcLocStartCol loc)
-      [] -> Nothing
-#else
-    location = Nothing
-#endif
 
 data Result = Success | Failure (Maybe Location) String | Error (Maybe Location) String
   deriving (Eq, Ord, Show)


### PR DESCRIPTION
This is to remove code duplication from `HUnit`, `hspec-core`, `hspec-wai`, `logging-facade`, etc.