### PR TITLE
Added the function 'runTestTTAndExit' to 'Test.HUnit.Text'.

### DIFF
--- a/src/Test/HUnit/Text.hs
+++ b/src/Test/HUnit/Text.hs
@@ -7,7 +7,8 @@ module Test.HUnit.Text
   putTextToHandle, putTextToShowS,
   runTestText,
   showPath, showCounts,
-  runTestTT
+  runTestTT,
+  runTestTTAndExit
 )
 where
 
@@ -16,6 +17,7 @@ import Test.HUnit.Base
 import Data.CallStack
 import Control.Monad (when)
 import System.IO (Handle, stderr, hPutStr, hPutStrLn)
+import System.Exit (exitSuccess, exitFailure)
 
 
 -- | As the general text-based test controller ('runTestText') executes a
@@ -130,3 +132,21 @@ showPath nodes = foldl1 f (map showNode nodes)
 runTestTT :: Test -> IO Counts
 runTestTT t = do (counts', 0) <- runTestText (putTextToHandle stderr True) t
                  return counts'
+
+-- | Convenience wrapper for 'runTestTT'. 
+--   Simply runs 'runTestTT' and then exits back to the OS,
+--   using 'exitSuccess' if there were no errors or failures,
+--   or 'exitFailure' if there were. For example:
+--
+--   > tests :: Test
+--   > tests = ...
+--   > 
+--   > main :: IO ()
+--   > main = runTestTTAndExit tests
+
+runTestTTAndExit :: Test -> IO ()
+runTestTTAndExit tests = do
+  c <- runTestTT tests
+  if (errors c == 0) && (failures c == 0)
+    then exitSuccess
+    else exitFailure


### PR DESCRIPTION
This is my first pull request on Github, my apologies if I've got something wrong.

This simply adds a function 'runTestTTAndExit' to the module 'Test.HUnit.Text', which just calls 'runTestTT', checks the counts, and if the failure and error count is zero, exits to the OS with success, otherwise exits with failure. I found myself rewriting this myself often for my tests, so I thought it might as well be added to the module proper.