### PR TITLE
Handle GHC 9.8's x-partial warning, requires dropping GHC 7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,51 +14,30 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os:
-          - ubuntu-18.04
+          - ubuntu-latest
         ghc:
-          - 7.0.1
-          - 7.0.4
-          - 7.2.2
-          - 7.4.1
-          - 7.4.2
-          - 7.6.3
-          - 7.8.4
-          - 7.10.3
           - 8.0.2
           - 8.2.2
-          - 8.4.1
-          - 8.4.2
-          - 8.4.3
           - 8.4.4
-          - 8.6.1
-          - 8.6.2
-          - 8.6.3
-          - 8.6.4
           - 8.6.5
-          - 8.8.1
-          - 8.8.2
-          - 8.8.3
           - 8.8.4
-          - 8.10.1
-          - 8.10.2
-          - 8.10.3
-          - 8.10.4
-          - 8.10.5
-          - 8.10.6
           - 8.10.7
-          - 9.0.1
           - 9.0.2
-          - 9.2.1
-          - 9.2.2
+          - 9.2.8
+          - 9.4.8
+          - 9.6.6
+          - 9.8.2
+          - 9.10.1
         include:
           - os: macos-latest
             ghc: latest
           - os: windows-latest
             ghc: latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: hspec/setup-haskell@v1
         with:
           ghc-version: ${{ matrix.ghc }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /dist/
 /HunitTest.tmp
+/.stack-work/
+/dist-newstyle/
+/stack*.yaml.lock

--- a/HUnit.cabal
+++ b/HUnit.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.3.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -30,7 +30,7 @@ library
   hs-source-dirs:
     src
   build-depends:
-    base ==4.*,
+    base >=4.9,
     call-stack >=0.3.0,
     deepseq
   exposed-modules:
@@ -52,7 +52,7 @@ test-suite tests
     examples
   build-depends:
     HUnit,
-    base ==4.*,
+    base >=4.9,
     call-stack >=0.3.0,
     deepseq,
     filepath

--- a/package.yaml
+++ b/package.yaml
@@ -16,7 +16,8 @@ extra-source-files:
   - README.md
 
 dependencies:
-  - base == 4.*
+  # GHC >= 8.0 required for -Wno-unrecognised-warning-flags
+  - base >= 4.9
   - deepseq
   - call-stack >= 0.3.0
 

--- a/src/Test/HUnit/Terminal.hs
+++ b/src/Test/HUnit/Terminal.hs
@@ -37,6 +37,5 @@ ta f (b:bs) as ('\b':cs) = ta f bs (b:as) cs
 ta _    ""   _ ('\b': _) = error "'\\b' at beginning of line"
 ta f    bs  as (c:cs)
     | not (isPrint c)    = error "invalid nonprinting character"
-    | null as            = ta f (c:bs) ""        cs
-    | otherwise          = ta f (c:bs) (tail as) cs
+    | otherwise          = ta f (c:bs) (drop 1 as) cs
 ta f    bs  as       ""  = f (reverse bs ++ as)

--- a/tests/HUnitTestExtended.hs
+++ b/tests/HUnitTestExtended.hs
@@ -1,3 +1,6 @@
+{-# OPTIONS_GHC -Wno-unrecognised-warning-flags #-}  -- since GHC 8.0
+{-# OPTIONS_GHC -Wno-x-partial #-}                   -- since GHC 9.8
+
 module HUnitTestExtended (extendedTests) where
 
 import Test.HUnit


### PR DESCRIPTION
Fixing a use of `tail` in the library.
In the test-suite, `tail []` is intended, so switch off the
`x-partial` there.

Ignoring `-Wx-partial` on older GHCs requires
`-Wno-unrecognised-warning-flags`, which entered GHC only in 8.0.
Thus, dropping GHC 7.

Closes #56.
